### PR TITLE
Update  recursive-open-struct 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,46 @@
+PATH
+  remote: .
+  specs:
+    scaleway (1.0.1)
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.9)
+      recursive-open-struct (~> 1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    faraday (0.11.0)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.11.0.1)
+      faraday (>= 0.7.4, < 1.0)
+    its (0.2.0)
+      rspec-core
+    multipart-post (2.0.0)
+    rake (10.5.0)
+    recursive-open-struct (1.0.2)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  its (~> 0.2)
+  rake (~> 10.1)
+  rspec (~> 3.1)
+  scaleway!
+
+BUNDLED WITH
+   1.13.6

--- a/scaleway.gemspec
+++ b/scaleway.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "faraday", "~> 0.9"
   gem.add_dependency "faraday_middleware", "~> 0.9"
-  gem.add_dependency "recursive-open-struct", "~> 0.5"
+  gem.add_dependency "recursive-open-struct", "~> 1.0"
 
   gem.add_development_dependency "rake", "~> 10.1"
   gem.add_development_dependency "rspec", "~> 3.1"


### PR DESCRIPTION
`recursive-open-struct` was a pretty old version. I tested with v1 and I looked into the CHANGELOG.md, and I didn't see anything problematic for the update